### PR TITLE
Set a minimum version for XML.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Depends:
     R (>= 3.0.1)
 Imports:
     httr (>= 0.5),
-    XML,
+    XML (>= 3.98),
     selectr,
     magrittr
 Suggests:


### PR DESCRIPTION
I'm sure that sufficiently old versions (circa 3.2) lead to problems; given that 3.98 is already ~1.5 years old, no reason to not start there.