### PR TITLE
case-insensitive filtering for submit input

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,9 @@
 
 * `submit_form()` now works with forms that use GET (#66).
 
+* `submit_request()` (and hence `submit_form()`) is now case-insensitive, 
+  and so will find `<input type=SUBMIT>` as well as`<input type="submit">`.
+
 # rvest 0.2.0
 
 ## New features

--- a/R/form.R
+++ b/R/form.R
@@ -277,7 +277,7 @@ submit_form <- function(session, form, submit = NULL, ...) {
 }
 
 submit_request <- function(form, submit = NULL) {
-  submits <- Filter(function(x) identical(x$type, "submit"), form$fields)
+  submits <- Filter(function(x) identical(tolower(x$type), "submit"), form$fields)
   if (is.null(submit)) {
     submit <- names(submits)[[1]]
     message("Submitting with '", submit, "'")


### PR DESCRIPTION
This will find HTML-allowable crud like `<input type=SUBMIT>` in addition to nicer stuff like `<input type="submit" name="Send">`.