### PR TITLE
escape hyperlink in jump_to()

### DIFF
--- a/R/session.R
+++ b/R/session.R
@@ -91,7 +91,9 @@ is.session <- function(x) inherits(x, "session")
 #' }
 jump_to <- function(x, url, ...) {
   stopifnot(is.session(x))
+
   url <- xml2::url_absolute(curl::curl_escape(url), x$url)
+
   x$back <- c(url, x$back)
   x$forward <- character()
   request_GET(x, url, ...)
@@ -128,6 +130,7 @@ follow_link <- function(x, i, css, xpath, ...) {
     }
     a <- links[[1]]
   }
+
   url <- html_attr(a, "href")
   message("Navigating to ", url)
   jump_to(x, url, ...)

--- a/R/session.R
+++ b/R/session.R
@@ -91,9 +91,7 @@ is.session <- function(x) inherits(x, "session")
 #' }
 jump_to <- function(x, url, ...) {
   stopifnot(is.session(x))
-
-  url <- xml2::url_absolute(url, x$url)
-
+  url <- xml2::url_absolute(curl::curl_escape(url), x$url)
   x$back <- c(url, x$back)
   x$forward <- character()
   request_GET(x, url, ...)
@@ -130,7 +128,6 @@ follow_link <- function(x, i, css, xpath, ...) {
     }
     a <- links[[1]]
   }
-
   url <- html_attr(a, "href")
   message("Navigating to ", url)
   jump_to(x, url, ...)


### PR DESCRIPTION
An example where this is relevant:

```r
library(rvest)
URL <- "http://www.wunderground.com/history/airport/KVAY/2015/2/17/DailyHistory.html?req_city=Cherry+Hill&req_state=NJ&req_statename=New+Jersey&reqdb.zip=08002&reqdb.magic=1&reqdb.wmo=99999&MR=1"
html_session(URL) %>% follow_link("Monthly")
```
