### PR TITLE
add form input images as valid submit buttons

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -23,7 +23,11 @@
 
 * `submit_request()` (and hence `submit_form()`) is now case-insensitive, 
   and so will find `<input type=SUBMIT>` as well as`<input type="submit">`.
-
+  
+* `submit_request()` (and hence `submit_form()`) recognizes forms with 
+  `<input type="image">` as a valid form submission button per
+  <http://www.w3.org/TR/html-markup/input.image.html>
+  
 # rvest 0.2.0
 
 ## New features

--- a/R/form.R
+++ b/R/form.R
@@ -277,7 +277,9 @@ submit_form <- function(session, form, submit = NULL, ...) {
 }
 
 submit_request <- function(form, submit = NULL) {
-  submits <- Filter(function(x) identical(tolower(x$type), "submit"), form$fields)
+  submits <- Filter(function(x) {
+      identical(tolower(x$type), "submit") | identical(tolower(x$type), "image")
+  }, form$fields)
   if (is.null(submit)) {
     submit <- names(submits)[[1]]
     message("Submitting with '", submit, "'")


### PR DESCRIPTION
The HTML spec allows forms to use `<input type="image">` elements as the submit button, but currently rvest doesn't recognize such elements as form submission targets.

Example:
```r
library(rvest)

entry_page <- html_session("http://dl.acm.org")

search <-
  entry_page %>% 
  html_nodes("form") %>% 
  .[[1]] %>% 
  html_form() %>% 
  set_values(
    query = "programming"
  )
  
entry_page %>% 
  submit_form(search, "Go")    # no element found

entry_page %>% 
  submit_form(search)      # error: subscript out of bounds
```