### PR TITLE
Use read_html() for all remaining instances of html()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,9 @@
 
 * Parse `<options>` that don't have value attribute (#85).
 
+* Remove all remaining uses of `html()` in favor of `read_html()` (@jimhester,
+  #113).
+
 # rvest 0.3.0
 
 * rvest has been rewritten to take advantage of the new xml2 package. xml2 

--- a/R/encoding.R
+++ b/R/encoding.R
@@ -30,7 +30,7 @@
 #' repair_encoding(x)
 #'
 #' # But it's better to start from scratch with correctly encoded file
-#' elections <- html(url, encoding = "UTF-8")
+#' elections <- read_html(url, encoding = "UTF-8")
 #' elections %>% html_nodes("table") %>% .[[2]] %>% html_table() %>% .$TO
 #' }
 NULL

--- a/R/session.R
+++ b/R/session.R
@@ -181,7 +181,7 @@ print.history <- function(x, ...) {
 # html methods -----------------------------------------------------------------
 
 #' @export
-html_form.session <- function(x) html_form(html(x))
+html_form.session <- function(x) html_form(read_html(x))
 
 #' @export
 html_table.session <- function(x, header = NA, trim = TRUE, fill = FALSE,

--- a/man/encoding.Rd
+++ b/man/encoding.Rd
@@ -44,7 +44,7 @@ guess_encoding(x)
 repair_encoding(x)
 
 # But it's better to start from scratch with correctly encoded file
-elections <- html(url, encoding = "UTF-8")
+elections <- read_html(url, encoding = "UTF-8")
 elections \%>\% html_nodes("table") \%>\% .[[2]] \%>\% html_table() \%>\% .$TO
 }
 }


### PR DESCRIPTION
There was one use in a example, and more importantly in `html_form.session()`, which I was using and generated the deprecation warning.

```bash
git grep '\bhtml('
```
Doesn't find any more instances, so I believe this should fix all of them.