### PR TITLE
Implementation of rowspan parsing plus tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rvest 0.3.1.9000
 
+* Parse rowspans effectively by filling downwards by repetition (#111)
+
 # rvest 0.3.1
 
 * Fix invalid link for SSA example.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rvest 0.3.1.9000
 
-* Parse rowspans effectively by filling downwards by repetition (#111)
+* Parse rowspans and colspans effectively by filling using repetition from left to right (for colspan) and top to bottom (rowspan) (#111)
 
 # rvest 0.3.1
 

--- a/R/table.R
+++ b/R/table.R
@@ -69,9 +69,10 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   p <- unique(vapply(ncols, sum, integer(1)))
   maxp <- max(p)
 
-  if (length(p) > 1 & (maxp * n != sum(unlist(nrows)))) {
-    # then malformed table is not parsable by rowspan solution
-    if (!fill) {
+  if (length(p) > 1 & maxp * n != sum(unlist(nrows)) &
+      maxp * n != sum(unlist(ncols))) {
+    # then malformed table is not parsable by smart filling solution
+    if (!fill) { # fill must then be specified to allow filling with NAs
       stop("Table has inconsistent number of columns. ",
            "Do you want fill = TRUE?", call. = FALSE)
     }
@@ -80,24 +81,30 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   values <- lapply(cells, html_text, trim = trim)
   out <- matrix(NA_character_, nrow = n, ncol = maxp)
 
+  # fill colspans right with repetition
   for (i in seq_len(n)) {
     row <- values[[i]]
     ncol <- ncols[[i]]
     col <- 1
-    for (j in seq_len(maxp)) {
-      if (j > length(row)) next
-      out[i, col] <- row[[j]]
+    for (j in seq_len(length(ncol))) {
+      out[i, col:(col+ncol[j]-1)] <- row[[j]]
       col <- col + ncol[j]
     }
   }
 
-  # fill rowspans downwards with repetition
+  # fill rowspans down with repetition
   for (i in seq_len(maxp)) {
-    col <- out[, i]
     for (j in seq_len(n)) {
-      rowspan <- nrows[[j]][i]
+      rowspan <- nrows[[j]][i]; colspan <- ncols[[j]][i]
       if (!is.na(rowspan) & (rowspan > 1)) {
-        for (k in seq_len(rowspan-1)) {
+        if (!is.na(colspan) & (colspan > 1)) {
+          # special case of colspan and rowspan in same cell
+          nrows[[j]] <- c(head(nrows[[j]], i),
+                          rep(rowspan, colspan-1),
+                          tail(nrows[[j]], length(rowspan)-(i+1)))
+          rowspan <- nrows[[j]][i]
+        }
+        for (k in seq_len(rowspan - 1)) {
           l <- head(out[j+k, ], i-1)
           r <- tail(out[j+k, ], maxp-i+1)
           out[j + k, ] <- head(c(l, out[j, i], r), maxp)
@@ -123,6 +130,10 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   names(df) <- col_names
   class(df) <- "data.frame"
   attr(df, "row.names") <- .set_row_names(length(df[[1]]))
+
+  if (length(unique(col_names)) < length(col_names)) {
+    warning('At least two columns have the same name')
+  }
 
   df
 }

--- a/R/table.R
+++ b/R/table.R
@@ -78,7 +78,7 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   }
 
   values <- lapply(cells, html_text, trim = trim)
-  out <- matrix(NA_character_, nrow = n, ncol = p)
+  out <- matrix(NA_character_, nrow = n, ncol = maxp)
 
   for (i in seq_len(n)) {
     row <- values[[i]]
@@ -94,7 +94,7 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   # fill rowspans downwards with repetition
   for (i in seq_len(maxp)) {
     col <- out[, i]
-    for (j in 1:n) {
+    for (j in seq_len(n)) {
       rowspan <- nrows[[j]][i]
       if (!is.na(rowspan) & (rowspan > 1)) {
         for (k in seq_len(rowspan-1)) {

--- a/R/table.R
+++ b/R/table.R
@@ -69,8 +69,8 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
   p <- unique(vapply(ncols, sum, integer(1)))
   maxp <- max(p)
 
-  if (length(p) > 1 & (maxp * n != Reduce(sum, lapply(nrows, sum)))) {
-    # then missing cells are not parsable by rowspan solution
+  if (length(p) > 1 & (maxp * n != sum(unlist(nrows)))) {
+    # then malformed table is not parsable by rowspan solution
     if (!fill) {
       stop("Table has inconsistent number of columns. ",
            "Do you want fill = TRUE?", call. = FALSE)

--- a/tests/testthat/test-tables.R
+++ b/tests/testthat/test-tables.R
@@ -47,62 +47,62 @@ test_that("a table with colspan only is correctly parsed", {
   select <- minimal_html("table parsing", '
                          <table class="reference" style="width:100%">
                          <tr>
-                         <th colspan="4">Data Columns</th>
+                           <th colspan="4">Data Columns</th>
                          </tr>
                          <tr>
-                         <th>Number</th>
-                         <th>First Name</th>
-                         <th>Last Name</th>
-                         <th>Points</th>
+                           <th>Number</th>
+                           <th>First Name</th>
+                           <th>Last Name</th>
+                           <th>Points</th>
                          </tr>
                          <tr>
-                         <td>1</td>
-                         <td>Eve</td>
-                         <td>Jackson</td>
-                         <td>94</td>
+                           <td>1</td>
+                           <td>Eve</td>
+                           <td>Jackson</td>
+                           <td>94</td>
                          </tr>
                          <tr>
-                         <td>4</td>
-                         <td>Jill</td>
-                         <td>Smith</td>
-                         <td>50</td>
+                           <td>4</td>
+                           <td>Jill</td>
+                           <td>Smith</td>
+                           <td>50</td>
                          </tr>
                          </table>')
   table <- select %>% html_node("table") %>% html_table(fill=T)
   expect_equal(table$`Data Columns`, c('Number', '1', '4'))
-  expect_equal(colnames(table), c("Data Columns", rep(NA, 3)))
+  expect_equal(colnames(table), rep("Data Columns", 4))
 })
 
 test_that("a table with a complex rowspan is correctly parsed", {
   select <- minimal_html("table parsing", '
                          <table class="reference" style="width:100%">
                          <tr>
-                         <th>State</th>
-                         <th>Name</th>
-                         <th>Eye Color</th>
+                           <th>State</th>
+                           <th>Name</th>
+                           <th>Eye Color</th>
                          </tr>
                          <tr>
-                         <td>OR</td>
-                         <td>Eve</td>
-                         <td rowspan="5">Brown</td>
+                           <td>OR</td>
+                           <td>Eve</td>
+                           <td rowspan="5">Brown</td>
                          </tr>
                          <tr>
-                         <td rowspan=3>AK</td>
-                         <td>Jill</td>
+                           <td rowspan=3>AK</td>
+                           <td>Jill</td>
                          </tr>
                          <tr>
-                         <td>John</td>
+                           <td>John</td>
                          </tr>
                          <tr>
-                         <td>Adam</td>
+                           <td>Adam</td>
                          </tr>
                          <tr>
-                         <td rowspan="2">OH</td>
-                         <td>Jim</td>
+                           <td rowspan="2">OH</td>
+                           <td>Jim</td>
                          </tr>
                          <tr>
-                         <td>Tony</td>
-                         <td>Blue</td>
+                           <td>Tony</td>
+                           <td>Blue</td>
                          </tr>
                          </table>')
   table <- select %>% html_node("table") %>% html_table()
@@ -116,40 +116,139 @@ test_that("a table with both rowspan and colspan issues is correctly parsed", {
   select <- minimal_html("table parsing", '
                          <table class="reference" style="width:100%">
                          <tr>
-                         <th colspan="3">Data Columns</th>
+                           <th colspan="3">Data Columns</th>
                          </tr>
                          <tr>
-                         <th>State</th>
-                         <th>Name</th>
-                         <th>Eye Color</th>
+                           <th>State</th>
+                           <th>Name</th>
+                           <th>Eye Color</th>
                          </tr>
                          <tr>
-                         <td>OR</td>
-                         <td>Eve</td>
-                         <td rowspan="5">Brown</td>
+                           <td>OR</td>
+                           <td>Eve</td>
+                           <td rowspan="5">Brown</td>
                          </tr>
                          <tr>
-                         <td rowspan=3>AK</td>
-                         <td>Jill</td>
+                           <td rowspan=3>AK</td>
+                           <td>Jill</td>
                          </tr>
                          <tr>
-                         <td>John</td>
+                          <td>John</td>
+                         </tr>
+                           <tr>
+                           <td>Adam</td>
                          </tr>
                          <tr>
-                         <td>Adam</td>
+                           <td rowspan="2">OH</td>
+                           <td>Jim</td>
                          </tr>
                          <tr>
-                         <td rowspan="2">OH</td>
-                         <td>Jim</td>
-                         </tr>
-                         <tr>
-                         <td>Tony</td>
-                         <td>Blue</td>
+                           <td>Tony</td>
+                           <td>Blue</td>
                          </tr>
                          </table>')
   table <- select %>% html_node("table") %>% html_table(fill=T)
   states <- c('OR', 'AK', 'AK', 'AK', 'OH', 'OH')
   names <- c('Eve', 'Jill', 'John', 'Adam', 'Jim', 'Tony')
   expect_equal(table$`Data Columns`, c('State', states))
-  expect_equal(colnames(table), c('Data Columns', NA, NA))
+  expect_equal(colnames(table), rep('Data Columns', 3))
+})
+
+test_that("a table with complex and multiple colspan issues is correctly parsed", {
+  select <- minimal_html("table parsing", '
+                         <table class="reference" style="width:100%">
+                         <tr>
+                           <th colspan="2">Categorical Columns</th>
+                           <th colspan="2">Numerical Columns</th>
+                         </tr>
+                         <tr>
+                           <td>A</th>
+                           <td>Small</th>
+                           <td>1.0</th>
+                           <td>2.3</th>
+                         </tr>
+                         <tr>
+                           <td colspan="3">NA</td>
+                           <td>4</td>
+                         </tr>
+                         </table>')
+  table <- select %>% html_node("table") %>% html_table(fill=T)
+  col1 <- c('A', NA)
+  col2 <- c('Small', NA)
+  col3 <- c(1, NA)
+  col4 <- c(2.3, 4)
+  expect_equal(table$`Categorical Columns`, col1)
+  expect_equal(table$`Numerical Columns`, col3)
+  expect_equal(table[,2], col2)
+  expect_equal(table[,4], col4)
+  expect_equal(colnames(table),
+               c(rep('Categorical Columns', 2),
+                 rep('Numerical Columns', 2)))
+})
+
+test_that("a cell with both rowspan and colspan is correctly parsed", {
+  select <- minimal_html("table parsing", '
+                         <table class="reference" style="width:100%">
+                         <tr>
+                           <th colspan="2" rowspan="2">Categorical Columns</th>
+                           <th colspan="2" rowspan="2">Numerical Columns</th>
+                         </tr>
+                         <tr></tr>
+                         <tr>
+                           <td>A</th>
+                           <td>Small</th>
+                           <td>1.0</th>
+                           <td>2.3</th>
+                         </tr>
+                         <tr>
+                           <td colspan="3">NA</td>
+                           <td>4</td>
+                         </tr>
+                         </table>')
+  table <- select %>% html_node("table") %>% html_table(fill=T)
+  col1 <- c('Categorical Columns', 'A', NA)
+  col2 <- c('Categorical Columns', 'Small', NA)
+  col3 <- c('Numerical Columns', "1.0", NA)
+  col4 <- c('Numerical Columns', 2.3, 4)
+  expect_equal(table$`Categorical Columns`, col1)
+  expect_equal(table$`Numerical Columns`, col3)
+  expect_equal(table[, 2], col2)
+  expect_equal(table[, 4], col4)
+  expect_equal(colnames(table),
+               c(rep('Categorical Columns', 2),
+                 rep('Numerical Columns', 2)))
+})
+
+test_that("a correct but slightly pathalogical table correctly parsed", {
+  select<- minimal_html("table parsing", '
+                         <table class="reference" style="width:100%">
+                         <tr>
+                           <th colspan="2" rowspan="3">Categorical Columns</th>
+                           <th colspan="2" rowspan="1">Numerical Columns</th>
+                         </tr>
+                         <tr><th>45</th></tr>
+                         <tr><th>95</th></tr>
+                         <tr>
+                           <td>A</th>
+                           <td>Small</th>
+                           <td>1.0</th>
+                           <td>2.3</th>
+                         </tr>
+                         <tr>
+                           <td colspan="3">NA</td>
+                           <td>4</td>
+                         </tr>
+                         </table>')
+  table <- select %>% html_node("table") %>% html_table(fill=T)
+  col1 <- c(rep('Categorical Columns', 2), 'A', NA)
+  col2 <- c(rep('Categorical Columns', 2), 'Small', NA)
+  col3 <- c(rep('Numerical Columns', 2), "1.0", NA)
+  col4 <- c(45, 95, 2.3, 4)
+  expect_equal(table$`Categorical Columns`, col1)
+  expect_equal(table$`Numerical Columns`, col3)
+  expect_equal(table[, 2], col2)
+  expect_equal(table[, 4], col4)
+  expect_equal(colnames(table),
+               c(rep('Categorical Columns', 2),
+                 rep('Numerical Columns', 2)))
 })


### PR DESCRIPTION
The main change was the "filling-in" of rowspan cells by repetition; which occurs after the colspan "filling"  (unchanged). In addition, one logic change to deciding whether or not to stop. fill=T is specified when the column number doesn't match up, I augmented the logic to only exit if the true number of cells cannot be discovered by interpreting the rowspan cells. Tests implemented cover (1) parsing colspan only, (2) rowspan only and (3) colspan and rowspan at the same time.