### PR TITLE
improve the markdown format of NEWS.md

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,8 +6,8 @@
 
 * Parse `<options>` that don't have value attribute (#85).
 
-* Remove all remaining uses of `html()` in favor of `read_html()` (@jimhester,
-  #113).
+* Remove all remaining uses of `html()` in favor of `read_html()` 
+  (@jimhester, #113).
 
 # rvest 0.3.0
 


### PR DESCRIPTION
Github accidentally recognizes `#` as a H1 header, which we intended to use as an issue number. This pull request is a work around for this clumsy behaviour.