### PR TITLE
fix utils::type.convert fail on Windows

### DIFF
--- a/R/table.R
+++ b/R/table.R
@@ -123,6 +123,11 @@ html_table.xml_node <- function(x, header = NA, trim = TRUE,
     col_names <- paste0("X", seq_len(ncol(out)))
   }
 
+  sys_enc <- "big5"  # OS locale dependent
+  if (.Platform$OS.type == "windows"){
+    out <- iconv(out, from="UTF-8", to = sys_enc)
+  }
+
   # Convert matrix to list to data frame
   df <- lapply(seq_len(maxp), function(i) {
     utils::type.convert(out[, i], as.is = TRUE, dec = dec)


### PR DESCRIPTION
```
Sys.setlocale("LC_CTYPE", "Chinese (Traditional)_Taiwan.950")
utils::type.convert(iconv("中文", to="UTF-8"), as.is=TRUE)
```
`utils::type.convert` fail processing UTF-8  multibyte string on Windows.