### PR TITLE
fixed typo in R/xml.R

### DIFF
--- a/R/xml.R
+++ b/R/xml.R
@@ -1,6 +1,6 @@
 #' Work with xml.
 #'
-#' Deprecated. Please use just xm2 directly
+#' Deprecated. Please use just xml2 directly
 #'
 #' @export
 #' @keywords internal


### PR DESCRIPTION
Fixed typo: changed "xm2" to "xml2"